### PR TITLE
Update debian to latest stable version bookworm

### DIFF
--- a/New-HyperVCloudImageVM.ps1
+++ b/New-HyperVCloudImageVM.ps1
@@ -276,14 +276,14 @@ Switch ($ImageVersion) {
     $ImageManifestSuffix = "json"
   }
   "testing" {
-    $_ = "sid"
-    $ImageVersion = "sid"
+    $_ = "trixie"
+    $ImageVersion = "trixie"
   }
-  "sid" {
+  "trixie" {
     $ImageOS = "debian"
-    $ImageVersionName = "sid"
+    $ImageVersionName = "trixie"
     $ImageRelease = "daily/latest" # default option is get latest but could be fixed to some specific version for example "release-20210413"
-    # http://cloud.debian.org/images/cloud/sid/daily/latest/debian-sid-azure-amd64-daily.tar.xz
+    # http://cloud.debian.org/images/cloud/trixie/daily/latest/debian-trixie-azure-amd64-daily.tar.xz
     $ImageBaseUrl = "http://cloud.debian.org/images/cloud"
     $ImageUrlRoot = "$ImageBaseUrl/$ImageVersionName/$ImageRelease/"
     #$ImageFileName = "$ImageOS-$ImageVersion-nocloud-amd64" # should contain "raw" version

--- a/New-HyperVCloudImageVM.ps1
+++ b/New-HyperVCloudImageVM.ps1
@@ -258,6 +258,23 @@ Switch ($ImageVersion) {
     $ImageHashFileName = "SHA512SUMS"
     $ImageManifestSuffix = "json"
   }
+  "12" {
+    $_ = "bookworm"
+    $ImageVersion = "12"
+  }
+  "bookworm" {
+    $ImageOS = "debian"
+    $ImageVersionName = "bookworm"
+    $ImageRelease = "latest" # default option is get latest but could be fixed to some specific version for example "release-20210413"
+    # http://cloud.debian.org/images/cloud/bookworm/latest/debian-12-azure-amd64.tar.xz
+    $ImageBaseUrl = "http://cloud.debian.org/images/cloud"
+    $ImageUrlRoot = "$ImageBaseUrl/$ImageVersionName/$ImageRelease/"
+    $ImageFileName = "$ImageOS-$ImageVersion-genericcloud-amd64" # should contain "raw" version
+    $ImageFileExtension = "tar.xz" # or "vhd.tar.gz" on older releases
+    # Manifest file is used for version check based on last modified HTTP header
+    $ImageHashFileName = "SHA512SUMS"
+    $ImageManifestSuffix = "json"
+  }
   "testing" {
     $_ = "sid"
     $ImageVersion = "sid"


### PR DESCRIPTION
in June 2023 a new stable version 12 of debian os was release, this is just an update to support debian 12.x