### PR TITLE
Fix issues with netplan v2 syntax

### DIFF
--- a/New-HyperVCloudImageVM.ps1
+++ b/New-HyperVCloudImageVM.ps1
@@ -400,13 +400,16 @@ config:
     Write-Verbose "v2 requested ..."
     $networkconfig = @"
 version: 2
-config: enabled
 ethernets:
   $($NetInterface):
-    dhcp: $NetAutoconfig
+    dhcp4: $NetAutoconfig
+    dhcp6: $NetAutoconfig
     #$(if (($null -eq $VMStaticMacAddress) -or ($VMStaticMacAddress -eq "")) { "#" })mac_address: $VMStaticMacAddress
-    $(if (($null -eq $NetAddress) -or ($NetAddress -eq "")) { "#" })addresses: $NetAddress
-    $(if (($null -eq $NetGateway) -or ($NetGateway -eq "")) { "#" })gateway4: $NetGateway
+    $(if (($null -eq $NetAddress) -or ($NetAddress -eq "")) { "#" })addresses:
+    $(if (($null -eq $NetAddress) -or ($NetAddress -eq "")) { "#" })  - $NetAddress
+    $(if (($null -eq $NetGateway) -or ($NetGateway -eq "")) { "#" })routes:
+    $(if (($null -eq $NetGateway) -or ($NetGateway -eq "")) { "#" })  - to: default
+    $(if (($null -eq $NetGateway) -or ($NetGateway -eq "")) { "#" })    via: $NetGateway
     nameservers:
       addresses: ['$($NameServers.Split(",") -join "', '" )']
       search: ['$($DomainName)']


### PR DESCRIPTION
Netplan no longer supports gateway4, or dhcp directives.  This PR aligns the netplan v2 format to the latest spec.