### PR TITLE
Fix New-HyperVCloudImageVM.ps1 error when using Chinese Regional format

### DIFF
--- a/New-HyperVCloudImageVM.ps1
+++ b/New-HyperVCloudImageVM.ps1
@@ -84,6 +84,9 @@ param(
   [switch] $Force = $false
 )
 
+[System.Threading.Thread]::CurrentThread.CurrentUICulture = "en-US"
+[System.Threading.Thread]::CurrentThread.CurrentCulture = "en-US"
+
 $NetAutoconfig = (($null -eq $NetAddress) -or ($NetAddress -eq "")) -and
                  (($null -eq $NetNetmask) -or ($NetNetmask -eq "")) -and
                  (($null -eq $NetNetwork) -or ($NetNetwork -eq "")) -and


### PR DESCRIPTION
This PR fixed the problem of using the `New-HyperVCloudImageVM.ps1` script with Chinese Regional format.
![image](https://github.com/schtritoff/hyperv-vm-provisioning/assets/15997384/2125a7a3-1a90-418b-9a69-50505d253a35)

When I'm using the script on my computer, I get the following error.
```
Cannot convert value "十" to type "System.Byte". Error: "Value was either too large or too small for an unsigned byte."
```
Which is caused by the command `Get-Date`.
![image](https://github.com/schtritoff/hyperv-vm-provisioning/assets/15997384/7967ea98-6514-4bdb-b091-5d8612054b75)