### PR TITLE
use netplan apply before doing the apt updates

### DIFF
--- a/New-HyperVCloudImageVM.ps1
+++ b/New-HyperVCloudImageVM.ps1
@@ -575,6 +575,13 @@ growpart:
   devices: [/]
   ignore_growroot_disabled: false
 
+# Workaround to apply network setting up before we apt update
+bootcmd:
+  - if [ ! -f /root/.first-run-complete ]; then netplan apply; fi
+
+runcmd:
+  - touch /root/.first-run-complete
+
 #apt:
 #  http_proxy: http://host:port
 #  https_proxy: http://host:port
@@ -718,6 +725,46 @@ write_files:
       echo "Disabled"
       fi
     path: /usr/libexec/hypervkvpd/hv_get_dhcp_info
+$(if ($ImageOS -eq "Ubuntu") { "  - content: |
+      #  This file is part of systemd.
+      #
+      #  systemd is free software; you can redistribute it and/or modify it under the
+      #  terms of the GNU Lesser General Public License as published by the Free
+      #  Software Foundation; either version 2.1 of the License, or (at your option)
+      #  any later version.
+      #
+      # Entries in this file show the compile time defaults. Local configuration
+      # should be created by either modifying this file (or a copy of it placed in
+      # /etc/ if the original file is shipped in /usr/), or by creating `"drop-ins`" in
+      # the /etc/systemd/resolved.conf.d/ directory. The latter is generally
+      # recommended. Defaults can be restored by simply deleting the main
+      # configuration file and all drop-ins located in /etc/.
+      #
+      # Use 'systemd-analyze cat-config systemd/resolved.conf' to display the full config.
+      #
+      # See resolved.conf(5) for details.
+      
+      [Resolve]
+      # Some examples of DNS servers which may be used for DNS= and FallbackDNS=:
+      # Cloudflare: 1.1.1.1#cloudflare-dns.com 1.0.0.1#cloudflare-dns.com 2606:4700:4700::1111#cloudflare-dns.com 2606:4700:4700::1001#cloudflare-dns.com
+      # Google:     8.8.8.8#dns.google 8.8.4.4#dns.google 2001:4860:4860::8888#dns.google 2001:4860:4860::8844#dns.google
+      # Quad9:      9.9.9.9#dns.quad9.net 149.112.112.112#dns.quad9.net 2620:fe::fe#dns.quad9.net 2620:fe::9#dns.quad9.net
+      # Nameservers set by New-HyperVCloudImageVM.ps1
+      DNS=$($NameServers.Split(",") -join " ")
+      #FallbackDNS=
+      #Domains=
+      #DNSSEC=
+      #DNSOverTLS=
+      #MulticastDNS=
+      #LLMNR=
+      #Cache=yes
+      #CacheFromLocalhost=no
+      #DNSStubListener=yes
+      #DNSStubListenerExtra=
+      #ReadEtcHosts=yes
+      #ResolveUnicastSingleLabel=no
+      #StaleRetentionSec=0
+    path: /etc/systemd/resolved.conf"})
 $(if ($null -ne $network_write_files) { $network_write_files
 })
 


### PR DESCRIPTION
the provisioning stalls when using alternative DNS servers as the DNS settings are not applied before apt update and apt upgrade run:

- add /etc/systemd/resolv.conf template to cloudimage
- do a netplan apply before calling apt

closes: #27